### PR TITLE
localhost (port 80) allowed for CORS usage

### DIFF
--- a/middlewares/cors.js
+++ b/middlewares/cors.js
@@ -3,6 +3,7 @@ const corsOptions = {
     const whitelist = [
       'http://localhost:3000',
       'http://localhost:8080',
+      'http://localhost',
       'http://umbrel.local',
       process.env.DEVICE_HOST,
     ];


### PR DESCRIPTION
Would like to allow localhost without a custom port in cors.