### PR TITLE
Add power cycle functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Set the following environment variables directly or by placing them in `.env` fi
 | `DEVICE_HOST` | IP or domain from where [`umbrel-dashboard`](https://github.com/getumbrel/umbrel-dashboard) will request | `http://umbrel.local` |
 | `USER_FILE` | Path to the user's data file (automatically created on user registration) | `/db/user.json` |
 | `SHUTDOWN_SIGNAL_FILE` | Path to write a file to signal a system shutdown | `/signals/shutdown` |
+| `REBOOT_SIGNAL_FILE` | Path to write a file to signal a system reboot | `/signals/reboot` |
 | `MIDDLEWARE_API_URL` | IP or domain where [`umbrel-middleware`](https://github.com/getumbrel/umbrel-middleware) is listening | `http://localhost` |
 | `MIDDLEWARE_API_PORT` | Port where [`umbrel-middleware`](https://github.com/getumbrel/umbrel-middleware) is listening | `3005` |
 | `JWT_PUBLIC_KEY_FILE` | Path to the JWT public key (automatically created) | `/db/jwt-public-key/jwt.pem` |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Set the following environment variables directly or by placing them in `.env` fi
 | `PORT` | Port where manager should listen for requests | `3006` |
 | `DEVICE_HOST` | IP or domain from where [`umbrel-dashboard`](https://github.com/getumbrel/umbrel-dashboard) will request | `http://umbrel.local` |
 | `USER_FILE` | Path to the user's data file (automatically created on user registration) | `/db/user.json` |
+| `SHUTDOWN_SIGNAL_FILE` | Path to write a file to signal a system shutdown | `/signals/shutdown` |
 | `MIDDLEWARE_API_URL` | IP or domain where [`umbrel-middleware`](https://github.com/getumbrel/umbrel-middleware) is listening | `http://localhost` |
 | `MIDDLEWARE_API_PORT` | Port where [`umbrel-middleware`](https://github.com/getumbrel/umbrel-middleware) is listening | `3005` |
 | `JWT_PUBLIC_KEY_FILE` | Path to the JWT public key (automatically created) | `/db/jwt-public-key/jwt.pem` |

--- a/logic/disk.js
+++ b/logic/disk.js
@@ -105,9 +105,9 @@ async function shutdown() {
   await diskService.writeFile(constants.SHUTDOWN_SIGNAL_FILE, 'true');
 }
 
-// Send a signal to relaunch the manager.
-async function relaunch() {
-  await diskService.writeFile(constants.RELAUNCH_SIGNAL_FILE, 'true');
+// Send a signal to reboot
+async function reboot() {
+  await diskService.writeFile(constants.REBOOT_SIGNAL_FILE, 'true');
 }
 
 // Read the contends of a file.
@@ -164,7 +164,7 @@ module.exports = {
   writeJWTPrivateKeyFile,
   writeJWTPublicKeyFile,
   shutdown,
-  relaunch,
+  reboot,
   readUtf8File,
   readJsonFile,
   writeMigrationStatusFile,

--- a/logic/disk.js
+++ b/logic/disk.js
@@ -100,12 +100,10 @@ function writeJWTPublicKeyFile(data) {
   return diskService.writeKeyFile(constants.JWT_PUBLIC_KEY_FILE, data);
 }
 
-// Send a signal to shutdown
 async function shutdown() {
   await diskService.writeFile(constants.SHUTDOWN_SIGNAL_FILE, 'true');
 }
 
-// Send a signal to reboot
 async function reboot() {
   await diskService.writeFile(constants.REBOOT_SIGNAL_FILE, 'true');
 }

--- a/logic/system.js
+++ b/logic/system.js
@@ -11,7 +11,17 @@ async function getHiddenServiceUrl() {
     }
 };
 
+async function requestShutdown() {
+    try {
+        await diskLogic.shutdown();
+        return "Shutdown requested";
+    } catch (error) {
+        throw new NodeError('Unable to request shutdown');
+    }
+};
+
 
 module.exports = {
-    getHiddenServiceUrl
+    getHiddenServiceUrl,
+    requestShutdown
 };

--- a/logic/system.js
+++ b/logic/system.js
@@ -20,8 +20,18 @@ async function requestShutdown() {
     }
 };
 
+async function requestReboot() {
+    try {
+        await diskLogic.reboot();
+        return "Reboot requested";
+    } catch (error) {
+        throw new NodeError('Unable to request reboot');
+    }
+};
+
 
 module.exports = {
     getHiddenServiceUrl,
-    requestShutdown
+    requestShutdown,
+    requestReboot
 };

--- a/routes/v1/system.js
+++ b/routes/v1/system.js
@@ -21,4 +21,10 @@ router.get('/shutdown', auth.jwt, safeHandler(async (req, res) => {
     return res.status(constants.STATUS_CODES.OK).json(result);
 }));
 
+router.get('/reboot', auth.jwt, safeHandler(async (req, res) => {
+    const result = await systemLogic.requestReboot();
+
+    return res.status(constants.STATUS_CODES.OK).json(result);
+}));
+
 module.exports = router;

--- a/routes/v1/system.js
+++ b/routes/v1/system.js
@@ -15,4 +15,10 @@ router.get('/dashboard-hidden-service', auth.jwt, safeHandler(async (req, res) =
     return res.status(constants.STATUS_CODES.OK).json(url);
 }));
 
+router.get('/shutdown', auth.jwt, safeHandler(async (req, res) => {
+    const result = await systemLogic.requestShutdown();
+
+    return res.status(constants.STATUS_CODES.OK).json(result);
+}));
+
 module.exports = router;

--- a/routes/v1/system.js
+++ b/routes/v1/system.js
@@ -15,13 +15,13 @@ router.get('/dashboard-hidden-service', auth.jwt, safeHandler(async (req, res) =
     return res.status(constants.STATUS_CODES.OK).json(url);
 }));
 
-router.get('/shutdown', auth.jwt, safeHandler(async (req, res) => {
+router.post('/shutdown', auth.jwt, safeHandler(async (req, res) => {
     const result = await systemLogic.requestShutdown();
 
     return res.status(constants.STATUS_CODES.OK).json(result);
 }));
 
-router.get('/reboot', auth.jwt, safeHandler(async (req, res) => {
+router.post('/reboot', auth.jwt, safeHandler(async (req, res) => {
     const result = await systemLogic.requestReboot();
 
     return res.status(constants.STATUS_CODES.OK).json(result);

--- a/utils/const.js
+++ b/utils/const.js
@@ -4,6 +4,7 @@ module.exports = {
   REQUEST_CORRELATION_ID_KEY: 'reqId',
   USER_FILE: process.env.USER_FILE || '/db/user.json',
   SHUTDOWN_SIGNAL_FILE: process.env.SHUTDOWN_SIGNAL_FILE || '/signals/shutdown',
+  REBOOT_SIGNAL_FILE: process.env.REBOOT_SIGNAL_FILE || '/signals/reboot',
   JWT_PUBLIC_KEY_FILE: process.env.JWT_PUBLIC_KEY_FILE || '/db/jwt-public-key/jwt.pem',
   JWT_PRIVATE_KEY_FILE: process.env.JWT_PRIVATE_KEY_FILE || '/db/jwt-private-key/jwt.key',
   DOCKER_COMPOSE_DIRECTORY: process.env.DOCKER_COMPOSE_DIRECTORY || '/docker-compose',

--- a/utils/const.js
+++ b/utils/const.js
@@ -3,6 +3,7 @@ module.exports = {
   REQUEST_CORRELATION_NAMESPACE_KEY: 'umbrel-manager-request',
   REQUEST_CORRELATION_ID_KEY: 'reqId',
   USER_FILE: process.env.USER_FILE || '/db/user.json',
+  SHUTDOWN_SIGNAL_FILE: process.env.SHUTDOWN_SIGNAL_FILE || '/signals/shutdown',
   JWT_PUBLIC_KEY_FILE: process.env.JWT_PUBLIC_KEY_FILE || '/db/jwt-public-key/jwt.pem',
   JWT_PRIVATE_KEY_FILE: process.env.JWT_PRIVATE_KEY_FILE || '/db/jwt-private-key/jwt.key',
   DOCKER_COMPOSE_DIRECTORY: process.env.DOCKER_COMPOSE_DIRECTORY || '/docker-compose',


### PR DESCRIPTION
Related:
- https://github.com/getumbrel/umbrel/pull/28
- https://github.com/getumbrel/umbrel-dashboard/pull/130

Add a `/v1/system/shutdown` endpoint to write to `SHUTDOWN_SIGNAL_FILE` on filesystem.
Add a `/v1/system/reboot` endpoint to write to `REBOOT_SIGNAL_FILE` on filesystem.