### PR TITLE
Use getumbrel/manager-builder image for faster builds

### DIFF
--- a/.github/workflows/on-push-builder.yml
+++ b/.github/workflows/on-push-builder.yml
@@ -1,0 +1,37 @@
+name: Build manager-builder image on push
+env:
+        DOCKER_CLI_EXPERIMENTAL: enabled
+
+on: push
+
+jobs:
+        build:
+                runs-on: ubuntu-18.04
+                name: Build and push manager-builder image
+                steps:                               
+                        - name: Login to Docker Hub
+                          run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+                        - name: Checkout project
+                          uses: actions/checkout@v2
+                        - name: Setup Docker buildx action
+                          uses: docker/setup-buildx-action@v1
+                          id: buildx
+                        - name: Cache Docker layers
+                          uses: actions/cache@v2
+                          id: cache
+                          with:
+                            path: /tmp/.buildx-cache
+                            key: ${{ runner.os }}-buildx-${{ github.sha }}
+                            restore-keys: |
+                              ${{ runner.os }}-buildx-
+                        - name: Show available buildx platforms
+                          run: echo ${{ steps.buildx.outputs.platforms }}
+                        - name: Run Docker buildx
+                          run: |
+                                  docker buildx build \
+                                  --cache-from "type=local,src=/tmp/.buildx-cache" \
+                                  --cache-to "type=local,dest=/tmp/.buildx-cache" \
+                                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+                                  --file Dockerfile.builder \
+                                  --tag ${{ secrets.DOCKER_HUB_USER }}/manager-builder:latest \
+                                  --output "type=registry" ./

--- a/.github/workflows/on-push-builder.yml
+++ b/.github/workflows/on-push-builder.yml
@@ -2,7 +2,10 @@ name: Build manager-builder image on push
 env:
         DOCKER_CLI_EXPERIMENTAL: enabled
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
         build:

--- a/.github/workflows/on-push-builder.yml
+++ b/.github/workflows/on-push-builder.yml
@@ -31,7 +31,7 @@ jobs:
                                   docker buildx build \
                                   --cache-from "type=local,src=/tmp/.buildx-cache" \
                                   --cache-to "type=local,dest=/tmp/.buildx-cache" \
-                                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+                                  --platform linux/amd64,linux/arm64 \
                                   --file Dockerfile.builder \
                                   --tag ${{ secrets.DOCKER_HUB_USER }}/manager-builder:latest \
                                   --output "type=registry" ./

--- a/.github/workflows/on-push-builder.yml
+++ b/.github/workflows/on-push-builder.yml
@@ -11,11 +11,18 @@ jobs:
                 steps:                               
                         - name: Login to Docker Hub
                           run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
                         - name: Checkout project
                           uses: actions/checkout@v2
+
+                        - name: Set up QEMU
+                          uses: docker/setup-qemu-action@v1
+                          id: qemu
+
                         - name: Setup Docker buildx action
                           uses: docker/setup-buildx-action@v1
                           id: buildx
+
                         - name: Cache Docker layers
                           uses: actions/cache@v2
                           id: cache
@@ -24,14 +31,16 @@ jobs:
                             key: ${{ runner.os }}-buildx-${{ github.sha }}
                             restore-keys: |
                               ${{ runner.os }}-buildx-
+
                         - name: Show available buildx platforms
                           run: echo ${{ steps.buildx.outputs.platforms }}
+                          
                         - name: Run Docker buildx
                           run: |
                                   docker buildx build \
                                   --cache-from "type=local,src=/tmp/.buildx-cache" \
                                   --cache-to "type=local,dest=/tmp/.buildx-cache" \
-                                  --platform linux/amd64,linux/arm64 \
+                                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
                                   --file Dockerfile.builder \
                                   --tag ${{ secrets.DOCKER_HUB_USER }}/manager-builder:latest \
                                   --output "type=registry" ./

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -39,6 +39,6 @@ jobs:
                                   docker buildx build \
                                   --cache-from "type=local,src=/tmp/.buildx-cache" \
                                   --cache-to "type=local,dest=/tmp/.buildx-cache" \
-                                  --platform linux/amd64,linux/arm64 \
+                                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
                                   --tag ${{ secrets.DOCKER_HUB_USER }}/manager:$BRANCH \
                                   --output "type=registry" ./

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -39,6 +39,6 @@ jobs:
                                   docker buildx build \
                                   --cache-from "type=local,src=/tmp/.buildx-cache" \
                                   --cache-to "type=local,dest=/tmp/.buildx-cache" \
-                                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+                                  --platform linux/amd64,linux/arm64 \
                                   --tag ${{ secrets.DOCKER_HUB_USER }}/manager:$BRANCH \
                                   --output "type=registry" ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM mayankchhabra/manager-builder:latest AS umbrel-manager-builder
+FROM getumbrel/manager-builder:latest AS umbrel-manager-builder
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM getumbrel/manager-builder:latest AS umbrel-manager-builder
+FROM mayankchhabra/manager-builder:latest AS umbrel-manager-builder
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,5 @@
 # Build Stage
-FROM node:12-buster-slim AS umbrel-manager-builder
-
-# Install tools
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libffi-dev \
-    && apt-get install -y libssl-dev \
-    && apt-get install -y python3 \
-    && apt-get install -y python3-pip \
-    && pip3 install -IU docker-compose \
-    && chmod +x /usr/local/bin/docker-compose
+FROM getumbrel/manager-builder:latest AS umbrel-manager-builder
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,12 @@
+# Build Stage
+FROM node:12-buster-slim
+
+# Install tools
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install -y libffi-dev \
+    && apt-get install -y libssl-dev \
+    && apt-get install -y python3 \
+    && apt-get install -y python3-pip \
+    && pip3 install -IU docker-compose \
+    && chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
Currently, the build times of `umbrel-manager` are painfully slow due the builder image taking a long while to build. In this PR, we separate out the builder image, and directly pull it at the time of build, reducing the image build time from ~1h15m to ~8m.