### PR TITLE
Fix whitespace in API responses

### DIFF
--- a/services/disk.js
+++ b/services/disk.js
@@ -109,8 +109,8 @@ function readFile(filePath, encoding) {
 }
 
 // Reads a file as a utf8 string. Wraps fs.readFile into a native promise
-function readUtf8File(filePath) {
-  return readFile(filePath, 'utf8').trim();
+async function readUtf8File(filePath) {
+  return (await readFile(filePath, 'utf8')).trim();
 }
 
 async function readJsonFile(filePath) {

--- a/services/disk.js
+++ b/services/disk.js
@@ -110,7 +110,7 @@ function readFile(filePath, encoding) {
 
 // Reads a file as a utf8 string. Wraps fs.readFile into a native promise
 function readUtf8File(filePath) {
-  return readFile(filePath, 'utf8');
+  return readFile(filePath, 'utf8').trim();
 }
 
 async function readJsonFile(filePath) {


### PR DESCRIPTION
When Tor hidden service hostname files are being read they end with a newline. When they are then built into Bitcoin/Electrum/LND connection strings and have extra information appended to them the newline gets sandwhiched between the data and breaks the connections string.

In the dashboard the connection strings are displayed in a text input and a QR code. The text input automatically strips out newlines so it works, but the QR code encodes the newlines so scanning the QR results in a broken connection string.

This PR automatically trims any trailing whitespace in the `readUtf8File()` method in the disk service to prevent this from ever happening.