### PR TITLE
Preserve user properties when updating password

### DIFF
--- a/logic/auth.js
+++ b/logic/auth.js
@@ -77,7 +77,7 @@ async function changePassword(currentPassword, newPassword, jwt) {
             const encryptedSeed = await iocane.createSession().encrypt(decryptedSeed, newPassword);
 
             // update user file
-            await diskLogic.writeUserFile({ name: user.name, password: credentials.password, seed: encryptedSeed });
+            await diskLogic.writeUserFile({ ...user, password: credentials.password, seed: encryptedSeed });
 
             // update ssh password
             // await hashAccountPassword(newPassword);


### PR DESCRIPTION
Without this change any property inside `user/db.json` other than `name`/`password`/`seed` gets deleted on password reset.

Replaces https://github.com/getumbrel/umbrel-manager/pull/67