### PR TITLE
Switch to modern-passport-http

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,6 +1,6 @@
 const passport = require('passport');
 const passportJWT = require('passport-jwt');
-const passportHTTP = require('passport-http');
+const passportHTTP = require('modern-passport-http');
 const bcrypt = require('bcrypt');
 const diskLogic = require('logic/disk.js');
 const authLogic = require('logic/auth.js');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node-rsa": "^1.0.8",
     "npm": "^6.14.6",
     "passport": "^0.4.0",
-    "passport-http": "^0.3.0",
+    "modern-passport-http": "^0.3.1",
     "passport-jwt": "^4.0.0",
     "request-promise": "^4.2.2",
     "semver": "^7.3.2",


### PR DESCRIPTION
This fork fixes a few bugs and uses mdoern JS (Buffer.from instead of Buffer, let/const instead of var, ...). If you don't trust me (which is understandable, Umbrel should be secure),
you can also fork it yourself﻿
.
