### PR TITLE
Set system password to Umbrel password

### DIFF
--- a/logic/auth.js
+++ b/logic/auth.js
@@ -174,6 +174,10 @@ async function login(user) {
 
         deriveUmbrelSeed(user)
 
+        // This is only needed temporarily to update hardcoded passwords
+        // on existing users without requiring them to change their password
+        setSystemPassword(user.password);
+
         return { jwt: jwt };
 
     } catch (error) {

--- a/logic/auth.js
+++ b/logic/auth.js
@@ -40,6 +40,12 @@ function getCachedPassword() {
     return devicePassword;
 }
 
+// Sets system password
+const setSystemPassword = async password => {
+  await diskLogic.writeStatusFile('update-password');
+  await diskLogic.writeSignalFile('update-password', password);
+}
+
 // Change the device and lnd password.
 async function changePassword(currentPassword, newPassword, jwt) {
 
@@ -79,8 +85,8 @@ async function changePassword(currentPassword, newPassword, jwt) {
             // update user file
             await diskLogic.writeUserFile({ ...user, password: credentials.password, seed: encryptedSeed });
 
-            // update ssh password
-            // await hashAccountPassword(newPassword);
+            // update system password
+            await setSystemPassword(newPassword);
 
             complete = true;
 
@@ -223,6 +229,13 @@ async function register(user, seed) {
         await diskLogic.writeUserFile({ name: user.name, password: user.password, seed: encryptedSeed });
     } catch (error) {
         throw new NodeError('Unable to register user');
+    }
+
+    //update system password
+    try {
+        await setSystemPassword(user.password);
+    } catch (error) {
+        throw new NodeError('Unable to set system password');
     }
 
     //derive Umbrel seed

--- a/logic/auth.js
+++ b/logic/auth.js
@@ -42,8 +42,8 @@ function getCachedPassword() {
 
 // Sets system password
 const setSystemPassword = async password => {
-  await diskLogic.writeStatusFile('change-password');
-  await diskLogic.writeSignalFile('change-password', password);
+  await diskLogic.writeStatusFile('password', password);
+  await diskLogic.writeSignalFile('change-password');
 }
 
 // Change the device and lnd password.

--- a/logic/auth.js
+++ b/logic/auth.js
@@ -42,8 +42,8 @@ function getCachedPassword() {
 
 // Sets system password
 const setSystemPassword = async password => {
-  await diskLogic.writeStatusFile('update-password');
-  await diskLogic.writeSignalFile('update-password', password);
+  await diskLogic.writeStatusFile('change-password');
+  await diskLogic.writeSignalFile('change-password', password);
 }
 
 // Change the device and lnd password.

--- a/logic/disk.js
+++ b/logic/disk.js
@@ -225,6 +225,16 @@ function writeSignalFile(signalFile) {
   return diskService.writeFile(signalFilePath, 'true');
 }
 
+// TODO: Transition all logic to use this status function
+function writeStatusFile(statusFile, contents) {
+  if(!/^[0-9a-zA-Z-_]+$/.test(statusFile)) {
+    throw new Error('Invalid signal file characters');
+  }
+
+  const statusFilePath = path.join(constants.STATUS_DIR, statusFile);
+  return diskService.writeFile(statusFilePath, contents);
+}
+
 function readAppRegistry() {
   const appRegistryFile = path.join(constants.APPS_DIR, 'registry.json');
   return diskService.readJsonFile(appRegistryFile);
@@ -284,6 +294,7 @@ module.exports = {
   enableSsh,
   readSshSignalFile,
   writeSignalFile,
+  writeStatusFile,
   readAppRegistry,
   readHiddenService,
 };

--- a/utils/const.js
+++ b/utils/const.js
@@ -5,6 +5,7 @@ module.exports = {
   DEVICE_HOSTNAME: process.env.DEVICE_HOSTNAME || 'umbrel.local',
   USER_FILE: process.env.USER_FILE || '/db/user.json',
   SIGNAL_DIR: process.env.SIGNAL_DIR || '/signals',
+  STATUS_DIR: process.env.STATUS_DIR || '/statuses',
   APPS_DIR: process.env.APPS_DIR || '/apps',
   TOR_HIDDEN_SERVICE_DIR: process.env.TOR_HIDDEN_SERVICE_DIR || '/var/lib/tor',
   SHUTDOWN_SIGNAL_FILE: process.env.SHUTDOWN_SIGNAL_FILE || '/signals/shutdown',


### PR DESCRIPTION
This calls the `change-password` trigger when the user's password when they first register and also when they do future password changes.

Since https://github.com/getumbrel/umbrel/pull/429 this trigger will update the `umbrel` user password on Umbrel OS which is used via SSH.