### PR TITLE
Fix incorrectly set password at register time

### DIFF
--- a/logic/auth.js
+++ b/logic/auth.js
@@ -211,7 +211,7 @@ async function register(user, seed) {
 
     //update system password
     try {
-        await setSystemPassword(user.password);
+        await setSystemPassword(user.plainTextPassword);
     } catch (error) {
         throw new NodeError('Unable to set system password');
     }


### PR DESCRIPTION
The system password was being set as `user.password` (ciphertext) instead of `user.plainTextPassword` (plaintext) at register time.

The system password would be correctly set at the next login when `user.password` is then plaintext not ciphertext.