### PR TITLE
Add memory monitoring API endpoints

### DIFF
--- a/logic/disk.js
+++ b/logic/disk.js
@@ -239,6 +239,26 @@ function writeStatusFile(statusFile, contents) {
   return diskService.writeFile(statusFilePath, contents);
 }
 
+function statusFileExists(statusFile) {
+  if(!/^[0-9a-zA-Z-_]+$/.test(statusFile)) {
+    throw new Error('Invalid signal file characters');
+  }
+
+  const statusFilePath = path.join(constants.STATUS_DIR, statusFile);
+  return diskService.readUtf8File(statusFilePath)
+    .then(() => Promise.resolve(true))
+    .catch(() => Promise.resolve(false));
+}
+
+function deleteStatusFile(statusFile) {
+  if(!/^[0-9a-zA-Z-_]+$/.test(statusFile)) {
+    throw new Error('Invalid signal file characters');
+  }
+
+  const statusFilePath = path.join(constants.STATUS_DIR, statusFile);
+  return diskService.deleteFile(statusFilePath);
+}
+
 function readAppRegistry() {
   const appRegistryFile = path.join(constants.APPS_DIR, 'registry.json');
   return diskService.readJsonFile(appRegistryFile);
@@ -250,6 +270,14 @@ function readHiddenService(id) {
   }
   const hiddenServiceFile = path.join(constants.TOR_HIDDEN_SERVICE_DIR, id, 'hostname');
   return diskService.readUtf8File(hiddenServiceFile);
+}
+
+function memoryWarningStatusFileExists() {
+  return statusFileExists('memory-warning');
+}
+
+function deleteMemoryWarningStatusFile() {
+  return deleteStatusFile('memory-warning');
 }
 
 module.exports = {
@@ -302,4 +330,6 @@ module.exports = {
   writeStatusFile,
   readAppRegistry,
   readHiddenService,
+  memoryWarningStatusFileExists,
+  deleteMemoryWarningStatusFile,
 };

--- a/logic/system.js
+++ b/logic/system.js
@@ -291,7 +291,25 @@ async function requestReboot() {
     }
 };
 
+async function status() {
+    try {
+      const highMemoryUsage = await diskLogic.memoryWarningStatusFileExists();
+      return {
+        highMemoryUsage
+      };
+    } catch (error) {
+        throw new NodeError('Unable check system status');
+    }
+};
 
+async function clearMemoryWarning() {
+    try {
+      await diskLogic.deleteMemoryWarningStatusFile();
+      return "High memory warning dismissed"
+    } catch (error) {
+        throw new NodeError('Unable to dismiss high memory warning');
+    }
+};
 
 module.exports = {
     getInfo,
@@ -307,5 +325,7 @@ module.exports = {
     requestDebug,
     getDebugResult,
     requestShutdown,
-    requestReboot
+    requestReboot,
+    status,
+    clearMemoryWarning,
 };

--- a/routes/v1/system.js
+++ b/routes/v1/system.js
@@ -14,6 +14,18 @@ router.get('/info', auth.jwt, safeHandler(async (req, res) => {
     return res.status(constants.STATUS_CODES.OK).json(info);
 }));
 
+router.get('/status', auth.jwt, safeHandler(async (req, res) => {
+    const status = await systemLogic.status();
+
+    return res.status(constants.STATUS_CODES.OK).json(status);
+}));
+
+router.post('/clear-memory-warning', auth.jwt, safeHandler(async (req, res) => {
+    const result = await systemLogic.clearMemoryWarning();
+
+    return res.status(constants.STATUS_CODES.OK).json(result);
+}));
+
 router.get('/dashboard-hidden-service', auth.jwt, safeHandler(async (req, res) => {
     const url = await systemLogic.getHiddenServiceUrl();
 


### PR DESCRIPTION
Adds a `GET /system/status` endpoint which currently only returns a `highMemoryUsage` boolean but can have more properties added in the future.

Also adds a `POST /system/clear-memory-warning` endpoint which clears the memory warning from `GET /system/status` until another high memory situation occurs.