### PR TITLE
Avoid caching when checking for updates

### DIFF
--- a/logic/system.js
+++ b/logic/system.js
@@ -94,7 +94,7 @@ async function getAvailableUpdate() {
         // Try finding for a new update until there's a new version available
         // which is compatible with the currently installed version
         while (isNewVersionAvailable && !isCompatibleWithCurrentVersion) {
-            const infoUrl = `https://raw.githubusercontent.com/${constants.GITHUB_REPO}/${tag}/info.json`;
+            const infoUrl = `https://raw.githubusercontent.com/${constants.GITHUB_REPO}/${tag}/info.json?time=${Date.now()}`;
 
             const latestVersionInfo = await axios.get(infoUrl);
             data = latestVersionInfo.data;


### PR DESCRIPTION
Some users seem to not get an updated copy of info.json (on master) when querying for update. Hopefully this fixes it.