### PR TITLE
Derive deterministic app passwords

### DIFF
--- a/logic/apps.js
+++ b/logic/apps.js
@@ -1,5 +1,6 @@
 const diskLogic = require('logic/disk.js');
 const NodeError = require('models/errors.js').NodeError;
+const deriveEntropy = require('modules/derive-entropy');
 
 async function get(query) {
   let apps = await diskLogic.readAppRegistry();
@@ -10,6 +11,15 @@ async function get(query) {
       app.hiddenService = await diskLogic.readHiddenService(`app-${app.id}`);
     } catch(e) {
       app.hiddenService = '';
+    }
+  }));
+
+  // Derive all passwords concurrently
+  await Promise.all(apps.filter(app => app.deterministicPassword).map(async app => {
+    try {
+      app.defaultPassword = await deriveEntropy(`app-${app.id}-seed-APP_PASSWORD`);
+    } catch(e) {
+      app.defaultPassword = '';
     }
   }));
 

--- a/modules/derive-entropy.js
+++ b/modules/derive-entropy.js
@@ -1,0 +1,16 @@
+const {promisify} = require('util');
+const readFile = promisify(require('fs').readFile);
+const crypto = require('crypto');
+
+const constants = require('utils/const.js');
+
+const deriveEntropy = async indentifier => {
+  const umbrel_seed = await readFile(constants.UMBREL_SEED_FILE);
+
+  return crypto
+    .createHmac('sha256', umbrel_seed)
+    .update(indentifier)
+    .digest('hex');
+};
+
+module.exports = deriveEntropy;


### PR DESCRIPTION
If an app has `deterministicPassword` set to true in the registry we know derive it's determinstic app password from the Umbrel seed and return it in the apps object.