### PR TITLE
Add 2FA to view seed and change password

### DIFF
--- a/middlewares/incorrectPasswordAuthHandler.js
+++ b/middlewares/incorrectPasswordAuthHandler.js
@@ -14,7 +14,7 @@ function handleError(error, req, res, next) {
     return next(new NodeError(error.message, 403));
   } else {
 
-    return next();
+    return next(error);
   }
 
 }

--- a/middlewares/incorrectPasswordAuthHandler.js
+++ b/middlewares/incorrectPasswordAuthHandler.js
@@ -4,13 +4,14 @@ const NodeError = require('models/errors.js').NodeError;
 
 function handleError(error, req, res, next) {
 
-  // If a incorrect password was given, respond with 403 instead of 401.
+  // If incorrect auth was given, respond with 403 instead of 401.
   // Reasoning: sending 401 on a request such as when the user tries to 
   // change password with an incorrect password or enters an incorrect
   // password to view seed will log him out due to interceptor on front-end
-  if (error.message && error.message === 'Incorrect password') {
+  const invalidAuthErrors = ['Incorrect password', 'Missing OTP token', 'Invalid OTP token'];
+  if (invalidAuthErrors.includes(error.message)) {
 
-    return next(new NodeError('Incorrect password', 403));
+    return next(new NodeError(error.message, 403));
   } else {
 
     return next();


### PR DESCRIPTION
Related: https://github.com/getumbrel/umbrel-dashboard/pull/398

OTP errors were getting swallowed by `incorrectPasswordAuthHandler`.